### PR TITLE
Adapter: Expose mubsub channel as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,10 @@ function adapter(uri, opts) {
 	// opts
 	var socket = opts.socket;
 	var client = opts.client;
+	var channel = opts.channel;
 	var key = opts.key || 'socket.io';
 	delete opts.key; // prevent key from being passed to mongoDB (via mubsub) and generating a warning
+	delete opts.channel;
 
 	// init clients if needed
 	if (!client) client = socket ? mubsub(socket) : mubsub(uri, opts);
@@ -38,7 +40,7 @@ function adapter(uri, opts) {
 	// this server's key
 	var uid = uid2(6);
 
-	var channel = client.channel(key);
+	var channel = channel || client.channel(key);
 
 	/**
 	 * Adapter constructor.


### PR DESCRIPTION
## Description

The adapter allows us to pass our own mubusb client in options. It will be helpful if the adapter allows us to pass the mubsub channel too (or if it can expose the channel somehow)
This will allow us to listen to channel events, and also to pass custom options